### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
 
   def index
     @items = Item.order('created_at DESC')
@@ -36,6 +36,13 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    if user_signed_in? && current_user.id == @item.user_id
+      @item.destroy
+      redirect_to root_path
+    end
+  end
+
   private
 
   def item_params
@@ -46,5 +53,6 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,10 +37,10 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if user_signed_in? && current_user.id == @item.user_id
-      @item.destroy
-      redirect_to root_path
-    end
+    return unless user_signed_in? && current_user.id == @item.user_id
+
+    @item.destroy
+    redirect_to root_path
   end
 
   private
@@ -53,6 +53,4 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
-
-
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -26,7 +26,7 @@
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% elsif user_signed_in?%>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update] 
+  resources :items 
 end


### PR DESCRIPTION
# What
ルーティングでitemsコントローラーのdestroyを設定、destroyアクションの作成

# Why
商品削除機能の実装のため


以下、挙動確認の動画です。
・ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画と、トップページで表示が消えていることを確認できる画像です。
https://gyazo.com/f1aad67fb638faa6f26be2c4f595bdae
https://gyazo.com/61ce8cda91c7064e100d06f6fe31001d